### PR TITLE
Configure staging alias for Now and document production deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Staging is deployed automatically from master: https://shields-raster-staging.no
 
 Production is deployed manually for now.
 
-To deploy, run `now alias shields-raster-staging.now.sh shields-raster.now.sh`
+To deploy, run `now alias shields-raster-staging.now.sh raster.shields.io`
 
 The production server is at: https://raster.shields.io/
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Designed for [Shields][] though may be useful for other application as well.
 
 Runs on Zeit Now.
 
+Staging is deployed automatically from master: https://shields-raster-staging.now.sh/
+
+Production is deployed manually for now.
+
+To deploy, run `now alias shields-raster-staging.now.sh shields-raster.now.sh`
+
+The production server is at: https://raster.shields.io/
+
 ## License
 
 This project is licensed under the MIT license.

--- a/now.json
+++ b/now.json
@@ -6,7 +6,7 @@
       "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD": "true"
     }
   },
-  "alias": "raster.shields-server.com",
+  "alias": "shields-raster-staging.now.sh",
   "env": {
     "BASE_URL": "https://img.shields.io"
   },

--- a/now.json
+++ b/now.json
@@ -6,6 +6,7 @@
       "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD": "true"
     }
   },
+  "alias": "raster.shields-server.com",
   "env": {
     "BASE_URL": "https://img.shields.io"
   },


### PR DESCRIPTION
Using this feature of Now for Git:

https://zeit.co/docs/v2/domains-and-aliases/aliasing-a-deployment/#with-now-for-git

New commits to master should be auto-aliased to `raster.shields-server.com`.

I've a slight preference that we auto-deploy to staging and then build some kind of one-click deploy to production, though that would create a bit of extra work and I'm not sure it's worth it. If other folks think it's important that we do that, I'm open to pursuing it.

Happy to merge this now to get a feel of it, though when we decide on a real production alias (https://github.com/badges/shields/issues/3112#issuecomment-507065715) we'll need to update this domain name.