### PR TITLE
Handle upstream 304's

### DIFF
--- a/rasterize.js
+++ b/rasterize.js
@@ -78,10 +78,15 @@ async function setup() {
       }
     })
 
+    if (statusCode === 304) {
+      // Do not send any content.
+      res.statusCode = 304
+      return ''
+    }
+
     if (isSvg(svg)) {
       return converter.convert(svg)
     } else {
-      console.log(`Expected svg, got: ${svg}`)
       res.statusCode = 502
       return errorBadge
     }

--- a/rasterize.js
+++ b/rasterize.js
@@ -77,6 +77,7 @@ async function setup() {
     if (isSvg(svg)) {
       return converter.convert(svg)
     } else {
+      console.log(`Expected svg, got: ${svg}`)
       res.statusCode = 502
       return errorBadge
     }

--- a/rasterize.js
+++ b/rasterize.js
@@ -63,10 +63,14 @@ async function setup() {
     const outUrl = new URL(outPath, baseUrl)
     outUrl.search = search
 
-    const { body: svg, headers: responseHeaders } = await got(outUrl, {
-      headers: requestHeaders,
-      throwHttpErrors: false,
-    })
+    const { body: svg, headers: responseHeaders, statusCode } = await got(
+      outUrl,
+      {
+        headers: requestHeaders,
+        throwHttpErrors: false,
+      }
+    )
+    console.log(`Status code ${statusCode}`)
 
     responseHeadersToForward.forEach(header => {
       if (header in responseHeaders) {


### PR DESCRIPTION
Every 2–5 requests I'm seeing an "invalid svg response" badge. Not sure what that's about! I'm temporarily logging the response and the status code to try to diagnose it.

We don't necessarily need to merge this. If we can fix the underlying problem that might be good enough.

----

Looks like the fix is to properly handle upstream 304s by responding with the forwarded headers and an empty body.

Steps to reproduce: load and then refresh a few times.

Working reliably: https://svg-to-image-proxy-git-debug-bad-svg.shields11.now.sh/badge/foo-bar-blue.svg
Every 2-5 requests fail: https://svg-to-image-proxy-afx697k8g.now.sh/badge/foo-bar-blue.svg