### PR TITLE
Redirect /, do it in config, and rename rasterize.js -> index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,6 @@ const responseHeadersToForward = [
   'last-modified',
 ]
 
-const ignoredPaths = ['/', '/favicon.ico']
-
 let cleanup
 async function setup() {
   const converter = createConverter({
@@ -53,11 +51,6 @@ async function setup() {
     // Ensure we're always using the `baseUrl` by using just the path from
     // the request URL.
     const { pathname, search } = new URL(req.url, 'https://bogus.test')
-
-    if (ignoredPaths.includes(pathname)) {
-      res.statusCode = 404
-      return ''
-    }
 
     const outPath = pathname.replace('.png', '.svg')
     const outUrl = new URL(outPath, baseUrl)

--- a/now.json
+++ b/now.json
@@ -18,7 +18,7 @@
     }
   ],
   "routes": [
-    { "src": "/(.*)", "dest": "/index.js" },
+    { "src": "/(.+)", "dest": "/index.js" },
     {
       "src": "/",
       "status": 301,

--- a/now.json
+++ b/now.json
@@ -12,10 +12,18 @@
   },
   "builds": [
     {
-      "src": "rasterize.js",
+      "src": "index.js",
       "use": "@now/node",
       "config": { "maxLambdaSize": "40mb" }
     }
   ],
-  "routes": [{ "src": "/(.*)", "dest": "/rasterize.js" }]
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.js" },
+    {
+      "src": "/",
+      "status": 301,
+      "headers": { "Location": "https://shields.io/" }
+    },
+    { "src": "/favicon.ico", "status": 404 }
+  ]
 }

--- a/now.json
+++ b/now.json
@@ -18,12 +18,12 @@
     }
   ],
   "routes": [
-    { "src": "/(.+)", "dest": "/index.js" },
     {
       "src": "/",
       "status": 301,
       "headers": { "Location": "https://shields.io/" }
     },
-    { "src": "/favicon.ico", "status": 404 }
+    { "src": "/favicon.ico", "status": 404 },
+    { "src": "/(.+)", "dest": "/index.js" }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "run-p lint prettier:check mocha",
     "start": "micro"
   },
-  "main": "rasterize.js",
   "repository": "badges/svg-to-image-proxy",
   "author": "Paul Melnikow",
   "license": "MIT",
@@ -50,6 +49,6 @@
     "test-listen": "^1.1.0"
   },
   "files": [
-    "rasterizer.js"
+    "index.js"
   ]
 }

--- a/test.js
+++ b/test.js
@@ -130,15 +130,4 @@ describe('svg-to-image-proxy endpoint', function() {
 
     scope.done()
   })
-
-  it('returns 404 for ignored paths', async function() {
-    const { body, statusCode } = await got(`${url}/favicon.ico`, {
-      encoding: null,
-      retry: { retries: 0 },
-      throwHttpErrors: false,
-    })
-
-    expect(statusCode).to.equal(404)
-    expect(Buffer.alloc(0).equals(body))
-  })
 })


### PR DESCRIPTION
@styfle pointed out that my tweet linked to https://raster.shields.io/ which is a 404. This redirects it to https://shields.io/. It also moves the redirect into config.

This makes it less portable (i.e. it won't work if you're self-hosting on your own infrastructure), though that may not be a big deal